### PR TITLE
Upgrade Add and Edit commands to implement Lock medical history

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -39,7 +39,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_BLOODTYPE + "AB+ "
-            + PREFIX_APPOINTMENT + "Nurse "
+            + PREFIX_APPOINTMENT + "Patient "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney "
             + PREFIX_MEDICAL_HISTORY + "Diabetes "
@@ -65,7 +65,7 @@ public class AddCommand extends Command {
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-
+        
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -61,6 +61,10 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_INVALID_MEDICAL_HISTORY = "Medical history should not be added to a nurse.";
+    public static final String MESSAGE_INVALID_MEDICAL_HISTORY_DELETE = "Delete medical history inorder "
+                                                                      + "to change to nurse appointment."
+                                                                      + " (e.g. edit 1 mh/ to remove medical history).";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -90,6 +94,8 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
+        ensureOnlyPatientCanHaveMedicalHistory(personToEdit, editedPerson);
+
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
@@ -97,6 +103,14 @@ public class EditCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         updateModelList(model);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+    }
+
+    private void ensureOnlyPatientCanHaveMedicalHistory(Person personToEdit, Person editedPerson) throws CommandException {
+        boolean editedPersonIsNurse = editedPerson.getAppointment().toString().equalsIgnoreCase("nurse");
+        boolean editedPersonHasMedicalHistory = !editedPerson.getMedicalHistory().isEmpty();
+        if (editedPersonIsNurse && editedPersonHasMedicalHistory) {
+            throw new CommandException(MESSAGE_INVALID_MEDICAL_HISTORY + "\n" + MESSAGE_INVALID_MEDICAL_HISTORY_DELETE);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -30,6 +30,8 @@ import seedu.address.model.tag.Tag;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    public static final String MESSAGE_INVALID_MEDICAL_HISTORY_ADD = "Medical history should not be added to a nurse";
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -55,12 +57,25 @@ public class AddCommandParser implements Parser<AddCommand> {
         BloodType bloodType = ParserUtil.parseBloodType(argMultimap.getValue(PREFIX_BLOODTYPE).get());
         Appointment appointment = ParserUtil.parseAppointment(argMultimap.getValue(PREFIX_APPOINTMENT).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        ensureNurseDoesNotHaveMedicalHistory(appointment, argMultimap, PREFIX_MEDICAL_HISTORY);
+
         Set<MedicalHistory> medicalHistoryList =
                 ParserUtil.parseMedicalHistories(argMultimap.getAllValues(PREFIX_MEDICAL_HISTORY));
 
         Person person = new Person(name, phone, email, address, bloodType, appointment, tagList, medicalHistoryList);
 
         return new AddCommand(person);
+    }
+
+    private void ensureNurseDoesNotHaveMedicalHistory(Appointment appointment,
+                                                      ArgumentMultimap argMultimap,
+                                                      Prefix prefix) throws ParseException {
+        boolean isNurse = appointment.toString().equalsIgnoreCase("nurse");
+        boolean hasMedicalHistory = !argMultimap.getValue(prefix).isEmpty();
+        if (isNurse && hasMedicalHistory) {
+            throw new ParseException(MESSAGE_INVALID_MEDICAL_HISTORY_ADD);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,23 +25,24 @@ public class Person {
     // Data fields
     private final Address address;
     private final BloodType bloodType;
-    private final Set<Tag> tags = new HashSet<>();
-    private final Set<MedicalHistory> medicalHistory = new HashSet<>();
+    private final Set<Tag> tags;
+    private final Set<MedicalHistory> medicalHistory;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, BloodType bloodType,
                   Appointment appointment, Set<Tag> tags, Set<MedicalHistory> medicalHistory) {
-        requireAllNonNull(name, phone, email, address, tags, bloodType);
+        requireAllNonNull(name, phone, email, address, bloodType, appointment);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
-        this.tags.addAll(tags);
         this.bloodType = bloodType;
         this.appointment = appointment;
-        this.medicalHistory.addAll(medicalHistory);
+
+        this.tags = (tags != null) ? new HashSet<>(tags) : new HashSet<>();
+        this.medicalHistory = (medicalHistory != null) ? new HashSet<>(medicalHistory) : new HashSet<>();
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,23 +23,23 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                new Address("Blk 30 Geylang Street 29, #06-40"), new BloodType("AB+"), new Appointment("Nurse"),
+                new Address("Blk 30 Geylang Street 29, #06-40"), new BloodType("AB+"), new Appointment("Patient"),
                     getTagSet("friends"), getMedicalHistorySet("Diabetes")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new BloodType("AB+"),
-                    new Appointment("Nurse"), getTagSet("colleagues", "friends"), getMedicalHistorySet("Asthma")),
+                    new Appointment("Nurse"), getTagSet("colleagues", "friends"), null),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new BloodType("AB+"), new Appointment("Nurse"),
-                    getTagSet("neighbours"), getMedicalHistorySet("Diabetes")),
+                    getTagSet("neighbours"), null),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new BloodType("AB+"),
-                    new Appointment("Nurse"), getTagSet("family"), getMedicalHistorySet("Diabetes")),
+                    new Appointment("Patient"), getTagSet("family"), getMedicalHistorySet("Diabetes")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
-                new Address("Blk 47 Tampines Street 20, #17-35"), new BloodType("AB+"), new Appointment("Nurse"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), new BloodType("AB+"), new Appointment("Patient"),
                     getTagSet("classmates"), getMedicalHistorySet("Diabetes")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new BloodType("AB+"), new Appointment("Nurse"),
-                    getTagSet("colleagues"), getMedicalHistorySet("Diabetes"))
+                    null, null)
         };
     }
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2425s2-cs2103t-t13-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
Changes made in this PR:

1. The add function now checks if adding a nurse with medical history, it will prompt an error that says "Medical history should not be added to a nurse" 
 
2. The edit function now checks if editing a nurse will add a medical history, it will prompt an error that says 
"Medical history should not be added to a nurse.
Delete medical history inorder to change to nurse appointment. (e.g. edit 1 mh/ to remove medical history)"

3. Put the correct link for the help command 

4. Made person object to accept optional tags and medical history, by passing it as null