### PR TITLE
Fix error messages for "view" command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -20,9 +22,16 @@ public class ViewCommandParser implements Parser<ViewCommand> {
     public ViewCommand parse(String args) throws ParseException {
         try {
             String[] splitArgs = args.trim().split("\\s");
-            if (splitArgs.length != 1) {
-                throw new ParseException("Usage: view INDEX");
+            if (splitArgs.length != 1 || splitArgs[0].isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
             }
+
+            try {
+                Integer.parseInt(splitArgs[0]);
+            } catch (NumberFormatException e) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
+            }
+
             Index index = ParserUtil.parseIndex(splitArgs[0]);
             return new ViewCommand(index);
         } catch (NumberFormatException e) {

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
@@ -22,26 +23,35 @@ public class ViewCommandParserTest {
 
     @Test
     public void parse_invalidArgsNonNumeric_throwsParseException() {
-        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("abc"));
+        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
+                -> parser.parse("abc"));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
     }
 
     @Test
     public void parse_invalidArgsNegative_throwsParseException() {
-        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("-1"));
+        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
+                -> parser.parse("-1"));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
     }
 
     @Test
     public void parse_invalidArgsZero_throwsParseException() {
-        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("0"));
+        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
+                -> parser.parse("0"));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
     }
 
     @Test
     public void parse_tooManyArgs_throwsParseException() {
-        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("1 2"));
+        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
+                -> parser.parse("1 2"));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
     }
 
     @Test
     public void parse_noArgs_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(""));
+        ParseException exception = assertThrows(ParseException.class, () -> parser.parse(""));
+        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -30,16 +30,12 @@ public class ViewCommandParserTest {
 
     @Test
     public void parse_invalidArgsNegative_throwsParseException() {
-        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
-                -> parser.parse("-1"));
-        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
+        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("-1"));
     }
 
     @Test
     public void parse_invalidArgsZero_throwsParseException() {
-        ParseException exception = assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, ()
-                -> parser.parse("0"));
-        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), exception.getMessage());
+        assertThrows(seedu.address.logic.parser.exceptions.ParseException.class, () -> parser.parse("0"));
     }
 
     @Test


### PR DESCRIPTION
Previously, some input cases for the view command were not handled properly, resulting in the wrong error message being shown to the user. This issue has been fixed to handle such input cases correctly.

Closes #189 