### PR TITLE
Edit and Assign nurse feature bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -69,6 +70,16 @@ public class EditCommand extends Command {
     public static final String MESSAGE_INVALID_MEDICAL_HISTORY_DELETE = "Delete medical history in order "
                                                                       + "to change to nurse appointment."
                                                                       + " (e.g. edit 1 mh/ to remove medical history).";
+    public static final String MESSAGE_UNABLE_TO_CHANGE_APPOINTMENT_TO_PATIENT = "Unable to change appointment to a "
+                                                                               + "patient, as "
+                                                                               + "this nurse is assigned to a patient.";
+    public static final String MESSAGE_UNABLE_TO_CHANGE_NAME = "Unable to change name, "
+                                                              + "as this nurse is assigned to a patient.";
+    public static final String MESSAGE_PERSON_IS_ALREADY_A_NURSE = "This person is already a nurse.";
+    public static final String MESSAGE_PERSON_IS_ALREADY_A_PATIENT = "This person is already a patient.";
+    public static final String MESSAGE_UNABLE_TO_CHANGE_APPOINTMENT_TO_NURSE = "Unable to change appointment to a "
+                                                                             + "nurse, as this patient is assigned "
+                                                                             + "to a nurse.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -99,6 +110,10 @@ public class EditCommand extends Command {
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         ensureOnlyPatientCanHaveMedicalHistory(editedPerson);
+        //ensureNotSameAppointment(personToEdit, editedPerson);
+        ensurePatientHasNoAssignedNurse(personToEdit, model);
+        ensureNurseHasNoPatient(personToEdit, editedPerson, model);
+        ensureChangeNameNurseIfNoPatient(personToEdit, model);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
@@ -109,11 +124,93 @@ public class EditCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 
+    // Ensure that a nurse can only change appointment to a patient if they have no patients assigned.
+    private void ensureNurseHasNoPatient(Person personToEdit, Person editedPerson,
+                                         Model personModel) throws CommandException {
+        requireNonNull(personToEdit);
+        requireNonNull(editedPerson);
+
+        if (editPersonDescriptor.getAppointment().isPresent()) {
+            Appointment appointmentBeforeEdit = personToEdit.getAppointment();
+            Appointment appointmentAfterEdit = editedPerson.getAppointment();
+            if (appointmentBeforeEdit.isNurse() && appointmentAfterEdit.isPatient()) {
+                String nameNoSpaces = personToEdit.getName().toString().replaceAll(" ", "");
+                boolean patientHasEditedNurse = personModel.getFilteredPersonList()
+                                                           .stream()
+                                                           .filter(person -> person.getAppointment().isPatient())
+                                                           .anyMatch(person -> person.getTags().stream()
+                                                           .anyMatch(tag -> tag.tagName
+                                                                                   .equals("Nurse" + nameNoSpaces)));
+
+                if (patientHasEditedNurse) {
+                    throw new CommandException(MESSAGE_UNABLE_TO_CHANGE_APPOINTMENT_TO_PATIENT);
+                }
+            }
+        }
+    }
+
+    // To ensure that a Nurse can only change name if they have no patients assigned.
+    private void ensureChangeNameNurseIfNoPatient(Person personToEdit, Model model) throws CommandException {
+        requireNonNull(personToEdit);
+        requireNonNull(model);
+
+        if (editPersonDescriptor.getName().isPresent()) {
+            Appointment appointmentBeforeEdit = personToEdit.getAppointment();
+            String nameNoSpaces = personToEdit.getName().toString().replaceAll(" ", "");
+            boolean nurseHasPatientAssigned = model.getFilteredPersonList()
+                                                   .stream()
+                                                   .filter(person -> person.getAppointment().isPatient())
+                                                   .anyMatch(person -> person.getTags().stream()
+                                                   .anyMatch(tag -> tag.tagName.equals("Nurse" + nameNoSpaces)));
+
+            if (appointmentBeforeEdit.isNurse() && nurseHasPatientAssigned) {
+                throw new CommandException(MESSAGE_UNABLE_TO_CHANGE_NAME);
+            }
+        }
+    }
+
+    // Ensure that a patient can change to a nurse if they have no medical history.
     private void ensureOnlyPatientCanHaveMedicalHistory(Person editedPerson) throws CommandException {
+        requireNonNull(editedPerson);
         boolean editedPersonIsNurse = editedPerson.isNurse();
         boolean editedPersonHasMedicalHistory = editedPerson.hasMedicalHistory();
         if (editedPersonIsNurse && editedPersonHasMedicalHistory) {
-            throw new CommandException(MESSAGE_INVALID_MEDICAL_HISTORY + "\n" + MESSAGE_INVALID_MEDICAL_HISTORY_DELETE);
+            throw new CommandException(MESSAGE_INVALID_MEDICAL_HISTORY + "\n"
+                                                                       + MESSAGE_INVALID_MEDICAL_HISTORY_DELETE);
+        }
+    }
+
+    // Ensure that a patient can change to a nurse if they have no assigned nurse.
+    private void ensurePatientHasNoAssignedNurse(Person personToEdit, Model personModel) throws CommandException {
+        if (editPersonDescriptor.getAppointment().isPresent()) {
+            String nameNoSpaces = personToEdit.getName().toString();
+            boolean hasNurseAssigned = personModel.getFilteredPersonList()
+                                                  .stream()
+                                                  .filter(person -> person.getName()
+                                                                                 .toString()
+                                                                                 .equalsIgnoreCase(nameNoSpaces))
+                                                  .anyMatch(person -> person.getTags().stream()
+                                                  .anyMatch(tag -> tag.tagName.startsWith("Nurse")));
+            boolean changeToPatient = editPersonDescriptor.getAppointment().get().isPatient();
+            if (personToEdit.isPatient() && hasNurseAssigned && !changeToPatient) {
+                throw new CommandException(MESSAGE_UNABLE_TO_CHANGE_APPOINTMENT_TO_NURSE);
+            }
+        }
+    }
+
+    private void ensureNotSameAppointment(Person personToEdit, Person editedPerson) throws CommandException {
+        requireNonNull(personToEdit);
+        requireNonNull(editedPerson);
+        if (editPersonDescriptor.getAppointment().isPresent()) {
+            boolean newAppointmentSameAsOld = personToEdit.getAppointment().equals(editedPerson.getAppointment());
+            if (newAppointmentSameAsOld) {
+                if (personToEdit.isNurse()) {
+                    throw new CommandException(MESSAGE_PERSON_IS_ALREADY_A_NURSE);
+                }
+                if (personToEdit.isPatient()) {
+                    throw new CommandException(MESSAGE_PERSON_IS_ALREADY_A_PATIENT);
+                }
+            }
         }
     }
 
@@ -145,11 +242,17 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         BloodType updatedBloodType = editPersonDescriptor.getBloodType().orElse(personToEdit.getBloodType());
         Appointment updatedAppointment = editPersonDescriptor.getAppointment().orElse(personToEdit.getAppointment());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Set<Tag> updatedTags = editPersonDescriptor.getTags().map(HashSet::new)
+                                                             .orElse(new HashSet<>(personToEdit.getTags()));
         NextOfKin nextOfKin = editPersonDescriptor.getNextOfKin().orElse(personToEdit.getNextOfKin());
         Set<MedicalHistory> updatedMedicalHistory = editPersonDescriptor.getMedicalHistory()
                                                                         .orElse(personToEdit.getMedicalHistory());
         Set<Checkup> currentCheckups = editPersonDescriptor.getCheckups().orElse(personToEdit.getCheckups());
+
+        if (personToEdit.isPatient()) {
+            updatedTags.addAll(personToEdit.getTags().stream().filter(tag -> tag.tagName.startsWith("Nurse"))
+                    .collect(Collectors.toSet()));
+        }
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedBloodType, updatedAppointment,
                 updatedTags, nextOfKin, updatedMedicalHistory, currentCheckups);

--- a/src/main/java/seedu/address/model/person/Appointment.java
+++ b/src/main/java/seedu/address/model/person/Appointment.java
@@ -41,6 +41,13 @@ public class Appointment {
         return this.toString().equalsIgnoreCase("nurse");
     }
 
+    /**
+     * Returns true if the appointment is patient and false otherwise.
+     */
+    public boolean isPatient() {
+        return this.toString().equalsIgnoreCase("patient");
+    }
+
     @Override
     public String toString() {
         return appointment;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -172,6 +172,13 @@ public class Person {
     }
 
     /**
+     * Returns true if the appointment is patient and false otherwise.
+     */
+    public boolean isPatient() {
+        return this.getAppointment().toString().equalsIgnoreCase("patient");
+    }
+
+    /**
      * Returns true if the person has medical history and false otherwise.
      */
     public boolean hasMedicalHistory() {

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -26,6 +26,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.CheckTagFromPreviousPerson;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
@@ -41,11 +42,14 @@ public class EditCommandTest {
         Person editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        Person personToEdit = model.getFilteredPersonList().get(0);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        Person editedPersonAfterTagCheck = new CheckTagFromPreviousPerson(personToEdit, editedPerson).build();
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                                               Messages.format(editedPersonAfterTagCheck));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPersonAfterTagCheck);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -116,7 +120,7 @@ public class EditCommandTest {
         // edit person in filtered list into a duplicate in address book
         Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder(personInList).build());
+                new EditPersonDescriptorBuilder(personInList).withAppointment("Patient").build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }

--- a/src/test/java/seedu/address/testutil/CheckTagFromPreviousPerson.java
+++ b/src/test/java/seedu/address/testutil/CheckTagFromPreviousPerson.java
@@ -1,0 +1,59 @@
+package seedu.address.testutil;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+/**
+ * A utility class to help with building a new Person object
+ * with updated tags based on the original person's tags that starts with "Nurse".
+ */
+public class CheckTagFromPreviousPerson {
+
+    private final Person originalPerson;
+    private final Person editedPerson;
+
+    /**
+     * Returns a {@code CheckTagFromPreviousPerson} with fields containing {@code editedPerson}'s details with
+     * {@code originalPerson}'s tags that starts with "Nurse".
+     *
+     * @param originalPerson The original person before editing.
+     * @param editedPerson The edited person after editing.
+     */
+    public CheckTagFromPreviousPerson(Person originalPerson, Person editedPerson) {
+        requireNonNull(originalPerson);
+        requireNonNull(editedPerson);
+        this.originalPerson = originalPerson;
+        this.editedPerson = editedPerson;
+    }
+
+    /**
+     * Checks if the original person has a tag that starts with "Nurse",
+     * it will be added to the updated tags for the edited person.
+     *
+     * @return a new Person object with updated tags.
+     */
+    public Person build() {
+        Set<Tag> updatedTags = new HashSet<>(editedPerson.getTags());
+
+        for (Tag tag : originalPerson.getTags()) {
+            if (tag.tagName.startsWith("Nurse")) {
+                updatedTags.add(tag);
+            }
+        }
+
+        return new Person(editedPerson.getName(),
+                          editedPerson.getPhone(),
+                          editedPerson.getEmail(),
+                          editedPerson.getAddress(),
+                          editedPerson.getBloodType(),
+                          editedPerson.getAppointment(),
+                          updatedTags,
+                          editedPerson.getNextOfKin(),
+                          editedPerson.getMedicalHistory());
+    }
+}

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -32,7 +32,7 @@ public class EditPersonDescriptorBuilder {
     }
 
     /**
-     * Returns an {@code EditPersonDescriptor} with fields containing {@code person}'s details
+     * Returns an {@code EditPersonDescriptor} with fields containing {@code person}'s details.
      */
     public EditPersonDescriptorBuilder(Person person) {
         descriptor = new EditPersonDescriptor();


### PR DESCRIPTION
Fixes made for EditCommand.java:
- Ensure that a nurse can only change appointment to a patient if they have no patients assigned
- Ensure that a nurse can only change a name if they have no patients assigned
- Ensure that a patient can change to a nurse if they have no assigned nurse
- If any of the above 4 checks are violated, an error message will be shown.


Fixes #194 