### PR TITLE
Allow find with prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -96,9 +96,8 @@ public class FindPatientCommand extends FindCommand {
 
     private boolean isPatientAssignedToNurse(Person patient, Person nurse) {
         Set<Tag> tags = patient.getTags();
-        String nurseNameWithoutSpaces = nurse.getName().toString().replace(" " , "")
-                .toUpperCase();
+        String nurseName = nurse.getName().toString().toUpperCase();
         return tags.stream()
-                .anyMatch(tag -> tag.tagName.toUpperCase().equals("NURSE" + nurseNameWithoutSpaces));
+                .anyMatch(tag -> tag.tagName.toUpperCase().equals("NURSE " + nurseName));
     }
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
@@ -18,8 +18,12 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        String fullName = person.getName().fullName.toUpperCase();
+        String[] nameParts = fullName.split(" ");
+
+        return Arrays.stream(nameParts)
+                .anyMatch(namePart -> keywords.stream()
+                        .anyMatch(keyword -> namePart.toUpperCase().startsWith(keyword.toUpperCase())));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindPatientCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_INVALID_NURSE;
 import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_NO_PATIENT_ASSIGNED;
 import static seedu.address.logic.commands.FindPatientCommand.MESSAGE_PATIENT_FOUND;
@@ -17,6 +16,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Appointment;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for RemarkCommand.
@@ -27,17 +28,21 @@ public class FindPatientCommandTest {
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndex_success() {
+    public void execute_validIndex_success() throws CommandException {
+        Model model1 = new ModelManager();
+        Person nurse = new PersonBuilder().withName("john lee").withAppointment("Nurse").build();
+        Person patient = new PersonBuilder().withName("alice doe").withAppointment("Patient")
+                .withTags("Nurse JOHN LEE").build();
+
+        model1.addPerson(nurse);
+        model1.addPerson(patient);
+
         Index validNurseIndex = Index.fromZeroBased(1);
         FindPatientCommand command = new FindPatientCommand(validNurseIndex);
 
-        try {
-            CommandResult result = command.execute(model);
-            assertEquals(String.format(MESSAGE_PATIENT_FOUND, "BENSON MEIER", "ALICE PAULINE"),
-                    result.getFeedbackToUser());
-        } catch (CommandException e) {
-            fail("Execution should not throw an exception: " + e.getMessage());
-        }
+        CommandResult result = command.execute(model1);
+        assertEquals(String.format(MESSAGE_PATIENT_FOUND, "JOHN LEE", "ALICE DOE"),
+                result.getFeedbackToUser());
     }
 
     @Test
@@ -79,35 +84,42 @@ public class FindPatientCommandTest {
     }
 
     @Test
-    public void execute_withoutFilter() {
+    public void execute_withoutFilter() throws CommandException {
+        Model model1 = new ModelManager();
+        Person nurse = new PersonBuilder().withName("john lee").withAppointment("Nurse").build();
+        Person patient = new PersonBuilder().withName("alice doe").withAppointment("Patient")
+                .withTags("Nurse JOHN LEE").build();
+
+        model1.addPerson(nurse);
+        model1.addPerson(patient);
+
         Index validNurseIndex = Index.fromZeroBased(1);
         FindPatientCommand findCommand = new FindPatientCommand(validNurseIndex);
 
-        try {
-            Command listCommand = new ListCommand(null);
-            listCommand.execute(model);
-            CommandResult result1 = findCommand.execute(model);
-            assertEquals(String.format(MESSAGE_PATIENT_FOUND, "BENSON MEIER", "ALICE PAULINE"),
-                    result1.getFeedbackToUser());
-        } catch (CommandException e) {
-            fail("Execution should not throw an exception: " + e.getMessage());
-        }
+        Command listCommand = new ListCommand(null);
+        listCommand.execute(model1);
+        CommandResult result1 = findCommand.execute(model1);
+        assertEquals(String.format(MESSAGE_PATIENT_FOUND, "JOHN LEE", "ALICE DOE"),
+                result1.getFeedbackToUser());
     }
 
     @Test
-    public void execute_withFilter() {
+    public void execute_withFilter() throws CommandException {
+        Model model1 = new ModelManager();
+        Person nurse = new PersonBuilder().withName("john lee").withAppointment("Nurse").build();
+        Person patient = new PersonBuilder().withName("alice doe").withAppointment("Patient")
+                .withTags("Nurse JOHN LEE").build();
+
+        model1.addPerson(nurse);
+        model1.addPerson(patient);
+
         Index validNurseIndex = Index.fromZeroBased(0);
         FindPatientCommand findCommand = new FindPatientCommand(validNurseIndex);
 
-        try {
-            Command listNurseCommand = new ListCommand(new Appointment("nurse"));
-            listNurseCommand.execute(model);
-            CommandResult result2 = findCommand.execute(model);
-            assertEquals(String.format(MESSAGE_PATIENT_FOUND, "BENSON MEIER", "ALICE PAULINE"),
-                    result2.getFeedbackToUser());
-        } catch (CommandException e) {
-            fail("Execution should not throw an exception: " + e.getMessage());
-        }
+        Command listNurseCommand = new ListCommand(new Appointment("nurse"));
+        listNurseCommand.execute(model1);
+        CommandResult result2 = findCommand.execute(model1);
+        assertEquals(String.format(MESSAGE_PATIENT_FOUND, "JOHN LEE", "ALICE DOE"),
+                result2.getFeedbackToUser());
     }
-
 }


### PR DESCRIPTION
Previously, find only worked if find keyword matched a person's full first name or last name. (e.g. "find al" would not list "alex yeoh", had to use "find alex" to list "alex yeoh")
Updated implementation to allow users to find people with prefixes of names.

Closes #182 