### PR TITLE
Edit "view" to show medical history as a list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -58,8 +58,8 @@ public class ViewCommand extends Command {
                     ? "No medical history available."
                     : viewedPerson.getMedicalHistory().stream()
                     .map(MedicalHistory::toString)
-                    .map(history -> history.replace("[", "").replace("]", ""))
-                    .collect(Collectors.joining(", "));
+                    .map(history -> "\n- " + history.replace("[", "").replace("]", ""))
+                    .collect(Collectors.joining(""));
             String medicalHistoryMessage = String.format(MESSAGE_MEDICAL_HISTORY, viewedPerson.getName(),
                     medicalHistory);
             responseMessage += "\n\n" + medicalHistoryMessage;

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -27,7 +27,7 @@ public class ViewCommandTest {
         CommandResult result = viewCommand.execute(model);
 
         String expected = String.format(ViewCommand.MESSAGE_SUCCESS, patient.getName()) + "\n\n"
-                + String.format(ViewCommand.MESSAGE_MEDICAL_HISTORY, patient.getName(), "High blood pressure");
+                + String.format(ViewCommand.MESSAGE_MEDICAL_HISTORY, patient.getName(), "\n- High blood pressure");
 
         assertEquals(expected, result.getFeedbackToUser());
     }


### PR DESCRIPTION
Previous implementation displayed patient medical history in a single line, separated by commas.
This implementation displays the medical history as a list to make it more readable.

Closes #224 